### PR TITLE
Removed deprecated LicenseUrl

### DIFF
--- a/Feature1/Feature1.csproj
+++ b/Feature1/Feature1.csproj
@@ -30,7 +30,8 @@
     <DebugType>portable</DebugType>
     
     <!--TODO: Fill these in-->
-    <PackageLicenseUrl>LINK TO LICENSE</PackageLicenseUrl>
+    <!--See the following for a list of valid license expressions: https://spdx.org/licenses/ -->
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>LINK TO PROJECT</PackageProjectUrl>
     <RepositoryUrl>LINK TO PROJECT</RepositoryUrl>
     <PackageReleaseNotes>RELEASE NOTES</PackageReleaseNotes>


### PR DESCRIPTION
`PackageLicenseUrl` is actually deprecated.

https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#packagelicenseurl

Should be replaced by either `PackageLicenseFile` or `PackageLicenseExpression`.

https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#packagelicenseexpression
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#packagelicensefile

Went with the expression for now including a link to valid values for it.